### PR TITLE
Add the URL as part of the response for an individual site GET request

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -23,6 +23,7 @@ type SitesResponse struct {
 // SiteResponse - JSON response for a single site
 type SiteResponse struct {
 	Key      string  `json:"key"`
+	URL      string  `json:"url"`
 	Statuses []int64 `json:"statuses"`
 }
 
@@ -100,6 +101,14 @@ func siteHandler(c *echo.Context) error {
 	}
 
 	resp := SiteResponse{Statuses: statuses, Key: siteKey}
+
+	// Get the appropriate URL for the response
+	for i := range AllSites {
+		if AllSites[i].Key == siteKey {
+			resp.URL = AllSites[i].URL
+			break
+		}
+	}
 
 	return c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
This was done partly to more easily get the URL while displaying statuses for that site on the front end, to help let the user know which URL the statuses pertain to.