### PR TITLE
Add back end capability to delete sites

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func main() {
 	e.Get("/sites", sitesHandler)
 	e.Post("/sites", createSiteHandler)
 	e.Get("/sites/:key", siteHandler)
+	e.Delete("/sites/:key", deleteSiteHandler)
 	e.Run(":" + serverPort)
 }
 

--- a/status.go
+++ b/status.go
@@ -36,6 +36,11 @@ func siteCheck(s Site) {
 		select {
 		case <-ticker.C:
 			go checkSiteStatus(s)
+		default:
+			if !contains(AllSites, s) {
+				ticker.Stop()
+				break
+			}
 		}
 	}
 }
@@ -79,4 +84,14 @@ func (s Site) LogStat(statKey string, val []byte) error {
 	}
 	err = redisClient.Ltrim(k, 0, minutesInMonth)
 	return err
+}
+
+// Helper function
+func contains(sites []Site, s Site) bool {
+	for i := range sites {
+		if sites[i] == s {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Added functionality on the back end to delete sites and no longer have them check the statuses of the deleted sites.

With curl, the request would look something like this:
`curl -X DELETE http://localhost:8989/sites/<site-key>`

Some existing code needed to be modified in order to allow re-adding deleted sites on POST requests, and to prevent the status checker from going to sites that have been deleted.