### PR TITLE
Switch storage to a relational datastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 .env
+*.bin
 TODO.md
 NOTES.md
 gin-bin

--- a/handlers.go
+++ b/handlers.go
@@ -9,29 +9,11 @@ import (
 	"github.com/labstack/echo"
 )
 
-// StatusPostInput - JSON Param input for adding a new status check
-type StatusPostInput struct {
-	URL   string `json:"url"`
-	Email string `json:"email"`
-}
-
-// SitesResponse - JSON response for listing sites
-type SitesResponse struct {
-	Sites []Site `json:"sites"`
-}
-
-// SiteResponse - JSON response for a single site
-type SiteResponse struct {
-	Key      string  `json:"key"`
-	Statuses []int64 `json:"statuses"`
-}
-
 // GET /sites
-//
 // response:
 //   sites: <array> sites registered with the system
 func sitesHandler(c *echo.Context) error {
-	return c.JSON(http.StatusOK, &SitesResponse{Sites: AllSites})
+	return c.JSON(http.StatusOK, AllSites)
 }
 
 // POST /sites
@@ -85,4 +67,17 @@ func siteHandler(c *echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, site)
+}
+
+// GET /sites/:key/checks
+func checksHandler(c *echo.Context) error {
+	siteKey := c.P(0)
+	var checks []Check
+
+	_, err := db.Select(&checks, "SELECT * FROM checks WHERE siteId=$1", siteKey)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusNotFound, "No checks found for site")
+	}
+
+	return c.JSON(http.StatusOK, checks)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"net/http"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo"
 )
@@ -43,37 +43,30 @@ func sitesHandler(c *echo.Context) error {
 // response:
 //   site: <json> newly created site info
 func createSiteHandler(c *echo.Context) error {
-	var params StatusPostInput
-	err := c.Bind(&params)
+	var site Site
+	err := c.Bind(&site)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Unable to decode JSON body")
 	}
 
-	params.URL = strings.TrimSpace(params.URL)
-	params.Email = strings.TrimSpace(params.Email)
+	site.HashId()
+	site.URL = strings.TrimSpace(site.URL)
+	site.Email = strings.ToLower(strings.TrimSpace(site.Email))
+	site.CreatedAt = time.Now()
+	site.UpdatedAt = time.Now()
 
-	if 0 == len(strings.TrimSpace(params.URL)) {
-		return c.JSON(http.StatusBadRequest, "URL parameter required")
+	if 0 == len(strings.TrimSpace(site.URL)) {
+		return c.JSON(http.StatusBadRequest, "Url parameter required")
 	}
 
-	newSite, err := redisClient.Sadd(redisScopedKey(sitesRedisKey), []byte(params.URL))
+	err = db.Insert(&site)
 	if err != nil {
+		log.Fatalf("Problem saving new site", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "Problem saving your new site")
 	}
 
-	if len(params.Email) > 0 {
-		_, err = redisClient.Hset(redisScopedKey(emailsRedisKey), params.URL, []byte(params.Email))
-		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "Problem saving your site email address to alert")
-		}
-	}
-
-	site := &Site{URL: params.URL}
-	site.Key = site.HashKey()
-	if newSite {
-		go siteCheck(*site)
-		AllSites = append(AllSites, *site)
-	}
+	go siteCheck(site)
+	AllSites = append(AllSites, site)
 	return c.JSON(http.StatusCreated, site)
 }
 
@@ -84,22 +77,12 @@ func createSiteHandler(c *echo.Context) error {
 //	 statuses: <array> chronologically ordered status codes from recent checks
 func siteHandler(c *echo.Context) error {
 	siteKey := c.P(0)
-	redisKey := redisScopedKey(fmt.Sprintf("%s:%s", uptimeRedisKey, siteKey))
+	var site Site
 
-	rawStatuses, err := redisClient.Lrange(redisKey, 0, minutesInMonth)
+	err := db.SelectOne(&site, "SELECT * FROM sites WHERE id=$1", siteKey)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return echo.NewHTTPError(http.StatusNotFound, "Site not found")
 	}
 
-	statuses := make([]int64, len(rawStatuses))
-	for i, s := range rawStatuses {
-		statuses[i], err = strconv.ParseInt(string(s), 10, 16)
-		if err != nil {
-			statuses[i] = 0
-		}
-	}
-
-	resp := SiteResponse{Statuses: statuses, Key: siteKey}
-
-	return c.JSON(http.StatusOK, resp)
+	return c.JSON(http.StatusOK, site)
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"crypto/md5"
 	"database/sql"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	_ "github.com/joho/godotenv/autoload"
 	"github.com/labstack/echo"
@@ -22,30 +20,6 @@ var (
 	AllSites []Site
 	db       *gorp.DbMap
 )
-
-type Site struct {
-	Id        string    `json:"id"`
-	URL       string    `json:"url"`
-	Email     string    `json:"email"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
-}
-
-func (s *Site) HashId() string {
-	if 0 == len(s.Id) {
-		s.Id = fmt.Sprintf("%x", md5.Sum([]byte(s.URL)))
-	}
-	return s.Id
-}
-
-type Check struct {
-	Id        int64     `json:"id"`
-	URL       string    `json:"url"`
-	Response  int       `json:"response"`
-	SiteId    string    `json:"siteId"`
-	CreatedAt time.Time `json:"createdAt"`
-}
 
 func main() {
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -39,6 +39,14 @@ func (s *Site) HashId() string {
 	return s.Id
 }
 
+type Check struct {
+	Id        int64     `json:"id"`
+	URL       string    `json:"url"`
+	Response  int       `json:"response"`
+	SiteId    string    `json:"siteId"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
 func main() {
 	flag.Parse()
 
@@ -62,6 +70,7 @@ func main() {
 	e.Get("/sites", sitesHandler)
 	e.Post("/sites", createSiteHandler)
 	e.Get("/sites/:key", siteHandler)
+	e.Get("/sites/:key/checks", checksHandler)
 	e.Run(":" + serverPort)
 }
 
@@ -81,6 +90,7 @@ func setupDb() *gorp.DbMap {
 	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
 
 	dbmap.AddTableWithName(Site{}, "sites")
+	dbmap.AddTableWithName(Check{}, "checks").SetKeys(true, "Id")
 
 	err = dbmap.CreateTablesIfNotExists()
 	if err != nil {

--- a/models.go
+++ b/models.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"time"
+)
+
+type Site struct {
+	Id        string    `json:"id"`
+	URL       string    `json:"url"`
+	Email     string    `json:"email"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (s *Site) HashId() string {
+	if 0 == len(s.Id) {
+		s.Id = fmt.Sprintf("%x", md5.Sum([]byte(s.URL)))
+	}
+	return s.Id
+}
+
+type Check struct {
+	Id        int64     `json:"id"`
+	URL       string    `json:"url"`
+	Response  int       `json:"response"`
+	SiteId    string    `json:"siteId"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/status.go
+++ b/status.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
 )
 
@@ -56,7 +55,7 @@ func checkSiteStatus(s Site) {
 
 	s.Status = resp.Status
 
-	err = s.LogStat([]byte(strconv.Itoa(resp.StatusCode)))
+	err = s.LogStat(resp.StatusCode)
 	if err != nil {
 		log.Println("[WARN] Error logging stat:", err.Error())
 	}
@@ -64,6 +63,12 @@ func checkSiteStatus(s Site) {
 	log.Println("[DEBUG]", s.URL, s.Status)
 }
 
-func (s Site) LogStat(val []byte) error {
-	return nil
+func (s Site) LogStat(status int) error {
+	var check Check
+	check.SiteId = s.Id
+	check.Response = status
+	check.URL = s.URL
+	check.CreatedAt = time.Now()
+	err := db.Insert(&check)
+	return err
 }

--- a/status.go
+++ b/status.go
@@ -47,8 +47,6 @@ func checkSiteStatus(s Site) {
 		return
 	}
 
-	s.PreviousStatus = s.Status
-
 	resp, err := http.Head(s.URL)
 	if err != nil {
 		s.Status = ERROR_STATUS
@@ -57,10 +55,8 @@ func checkSiteStatus(s Site) {
 	}
 
 	s.Status = resp.Status
-	s.StatusCode = resp.StatusCode
-	s.LastCheck = time.Now()
 
-	err = s.LogStat(uptimeRedisKey, []byte(strconv.Itoa(s.StatusCode)))
+	err = s.LogStat([]byte(strconv.Itoa(resp.StatusCode)))
 	if err != nil {
 		log.Println("[WARN] Error logging stat:", err.Error())
 	}
@@ -68,15 +64,6 @@ func checkSiteStatus(s Site) {
 	log.Println("[DEBUG]", s.URL, s.Status)
 }
 
-func (s Site) LogStat(statKey string, val []byte) error {
-	k := redisScopedKey(fmt.Sprintf("%s:%s", statKey, s.HashKey()))
-
-	// When using LPUSH + LTRIM immediately this is really an O(1) operation because in the average
-	// case just one element is removed from the tail of the list
-	err := redisClient.Lpush(k, val)
-	if err != nil {
-		return err
-	}
-	err = redisClient.Ltrim(k, 0, minutesInMonth)
-	return err
+func (s Site) LogStat(val []byte) error {
+	return nil
 }


### PR DESCRIPTION
Added [Gorp](https://github.com/go-gorp/gorp) for interacting with relational databases so we can support multiple database types: Postgres, MySQL, and SQLite. There is 3rd party support for other databases as well as the ability to write custom drivers.

This PR changes the API by removing response wrappers in favor of just returning the arrays of objects directly. There are also additional fields for the `Site` type that get returned in the `/sites` and `/sites/:id` endpoints.

All checks are now being logged in a `checks` table and can be accessed per site at `/sites/:id/checks`. The checks have the sites id for reference as well as createdAt and response columns.

A few other minor changes are made as well such as: Adding sqlite's .bin file to .gitignore, and moving the model struct types to a separate file.