### PR TITLE
Add back end capability to delete sites (with updated DB)

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	serverPort = os.Getenv("PORT")
 
-	AllSites []Site
+	AllSites map[string]Site
 	db       *gorp.DbMap
 )
 
@@ -45,13 +45,23 @@ func main() {
 	e.Post("/sites", createSiteHandler)
 	e.Get("/sites/:key", siteHandler)
 	e.Get("/sites/:key/checks", checksHandler)
+	e.Delete("/sites/:key", deleteSiteHandler)
 	e.Run(":" + serverPort)
 }
 
-func loadSites() ([]Site, error) {
+func loadSites() (map[string]Site, error) {
 	var sites []Site
+	sitesMap := make(map[string]Site)
 	_, err := db.Select(&sites, "SELECT * FROM sites ORDER BY CreatedAt DESC")
-	return sites, err
+	if err != nil {
+		return sitesMap, err
+	}
+
+	for _, site := range sites {
+		sitesMap[site.Id] = site
+	}
+
+	return sitesMap, err
 }
 
 func setupDb() *gorp.DbMap {

--- a/status.go
+++ b/status.go
@@ -15,7 +15,7 @@ var (
 	minutesInMonth = 30 * minutesInDay
 )
 
-func startStatusCheckers(sites []Site) error {
+func startStatusCheckers(sites map[string]Site) error {
 	for _, s := range sites {
 		fmt.Println("**", s.URL)
 		go siteCheck(s)
@@ -35,6 +35,12 @@ func siteCheck(s Site) {
 		select {
 		case <-ticker.C:
 			go checkSiteStatus(s)
+		default:
+			_, ok := AllSites[s.Id]
+			if !ok {
+				ticker.Stop()
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added functionality on the back end to delete sites and no longer have them check the statuses of the deleted sites.

With curl, the request would look something like this:
`curl -X DELETE http://localhost:8989/sites/<site-key>`

Some existing code needed to be modified in order to allow re-adding deleted sites on POST requests, and to prevent the status checker from going to sites that have been deleted.  Most notably, the `AllSites` array was changed to a map to allow for easier insertion and deletion.