### PR TITLE
Set primary key in sites database

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func setupDb() *gorp.DbMap {
 
 	dbmap := &gorp.DbMap{Db: db, Dialect: gorp.SqliteDialect{}}
 
-	dbmap.AddTableWithName(Site{}, "sites")
+	dbmap.AddTableWithName(Site{}, "sites").SetKeys(false, "Id")
 	dbmap.AddTableWithName(Check{}, "checks").SetKeys(true, "Id")
 
 	err = dbmap.CreateTablesIfNotExists()


### PR DESCRIPTION
Set the site ID as the primary key in the sites database, in order to prevent duplicate entries.