### PR TITLE
Add "immediate" flag to gin task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ build: *.go
 	go build -o build/situation-room
 
 gin:
-	@gin -a 4567 -p 8989
+	@gin -i -a 4567 -p 8989


### PR DESCRIPTION
Starts the server right away without needing to hit an endpoint. Must
upgrade to newest gin binary for this feature