### PR TITLE
Update site and status lists without having to refresh the page

### DIFF
--- a/client/src/app/behaviors/update-times-interval.coffee
+++ b/client/src/app/behaviors/update-times-interval.coffee
@@ -1,0 +1,14 @@
+$ = require('jquery')
+Marionette = require('backbone.marionette')
+
+module.exports = Marionette.Behavior.extend(
+
+  onRender: ->
+    @view.statusInterval = setInterval ( => @updateCollection() ), 1000 * 60
+
+  onDestroy: ->
+    clearInterval(@view.statusInterval)
+
+  updateCollection: ->
+    @view.collection.fetch({ reset: true })
+)

--- a/client/src/app/route-controller.coffee
+++ b/client/src/app/route-controller.coffee
@@ -2,6 +2,7 @@ $ = require('jquery')
 Marionette = require('backbone.marionette')
 ListSitesView = require('./views/list-sites')
 SiteStatusesView = require('./views/site-statuses')
+SiteCollection = require('./collections/site-collection')
 StatusCollection = require('./collections/status-collection')
 FormView = require('./views/form')
 SiteModel = require('./models/site')
@@ -20,13 +21,16 @@ module.exports = Marionette.Object.extend(
     showInRoot(new FormView())
 
   listSites: ->
-    showInRoot(new ListSitesView())
+    siteCollection = new SiteCollection()
+    siteCollection.fetch(
+      success: ->
+        showInRoot(new ListSitesView(collection: siteCollection))
+    )
 
   viewSite: (id) ->
-    statusCollection = new StatusCollection(key: id)
+    statusCollection = new StatusCollection()
     statusCollection.url = "/sites/#{id}/checks"
     statusCollection.fetch(
-      reset: true
       success: ->
         showInRoot(new SiteStatusesView(collection: statusCollection))
     )

--- a/client/src/app/views/list-sites.coffee
+++ b/client/src/app/views/list-sites.coffee
@@ -2,14 +2,17 @@ $ = require('jquery')
 Marionette = require('backbone.marionette')
 SiteView = require('./site')
 NoSitesView = require('./no-sites')
-SiteCollection = require('../collections/site-collection')
+UpdateTimes = require('../behaviors/update-times-interval')
 
 module.exports = Marionette.CompositeView.extend(
-  collection: new SiteCollection()
   childView: SiteView
   childViewContainer: 'tbody'
   emptyView: NoSitesView
   template: require('../templates/list-sites.jade')
-  initialize: ->
-    @collection.fetch({ reset: true })
+
+  behaviors: {
+    UpdateTimes: {
+      behaviorClass: UpdateTimes
+    }
+  }
 )

--- a/client/src/app/views/site-statuses.coffee
+++ b/client/src/app/views/site-statuses.coffee
@@ -1,11 +1,19 @@
 $ = require('jquery')
 Marionette = require('backbone.marionette')
 StatusView = require('./status')
+StatusCollection = require('../collections/status-collection')
 NoSitesView = require('./no-sites')
+UpdateTimes = require('../behaviors/update-times-interval')
 
 module.exports = Marionette.CompositeView.extend(
   childView: StatusView
   childViewContainer: 'tbody'
   emptyView: NoSitesView
   template: require('../templates/list-statuses.jade')
+
+  behaviors: {
+    UpdateTimes: {
+      behaviorClass: UpdateTimes
+    }
+  }
 )


### PR DESCRIPTION
Set a 1 minute interval to update the time checked for the sites and the statuses, depending on the page currently being viewed.
