### PR TITLE
Show charts for site statuses

### DIFF
--- a/client/src/app/helpers/status-chart-colors.coffee
+++ b/client/src/app/helpers/status-chart-colors.coffee
@@ -1,0 +1,94 @@
+statusColors = [
+  {
+    code: 200
+    chartColors : {
+      color: "#248d24"
+      highlight: "#2db42d"
+      label: "200 - OK"
+    }
+  }
+  {
+    code: 301
+    chartColors : {
+      color: "#b8d000"
+      highlight: "#e2ff00"
+      label: "301 - Moved Permanently"
+    }
+  }
+  {
+    code: 302
+    chartColors : {
+      color: "#ddb400"
+      highlight: "#dd0"
+      label: "302 - Moved Temporarily"
+    }
+  }
+  {
+    code: 400
+    chartColors : {
+      color: "#800000"
+      highlight: "#900"
+      label: "400 - Bad Request"
+    }
+  }
+  {
+    code: 401
+    chartColors : {
+      color: "#a10000"
+      highlight: "#c93e3e"
+      label: "401 - Unauthorized"
+    }
+  }
+  {
+    code: 403
+    chartColors : {
+      color: "#ab1515"
+      highlight: "#e83f3f"
+      label: "403 - Forbidden"
+    }
+  }
+  {
+    code: 404
+    chartColors : {
+      color: "#b00"
+      highlight: "#ed1b24"
+      label: "404 - Not found"
+    }
+  }
+  {
+    code: 500
+    chartColors : {
+      color: "#0500a3"
+      highlight: "#4a45cc"
+      label: "500 - Internal Server Error"
+    }
+  }
+  {
+    code: 502
+    chartColors : {
+      color: "#0700d1"
+      highlight: "#7976de"
+      label: "502 - Bad Gateway"
+    }
+  }
+  {
+    code: 503
+    chartColors : {
+      color: "#000d6e"
+      highlight: "#2c40d4"
+      label: "503 - Service Unavailable"
+    }
+  }
+]
+
+findColorByCode = (code) ->
+  chartColors = {}
+  statusColors.forEach( (status) ->
+    chartColors = status.chartColors if status.code is code
+    return
+  )
+  return chartColors
+
+module.exports =
+  statusColors: statusColors
+  findColorByCode: findColorByCode

--- a/client/src/app/route-controller.coffee
+++ b/client/src/app/route-controller.coffee
@@ -2,6 +2,7 @@ $ = require('jquery')
 Marionette = require('backbone.marionette')
 ListSitesView = require('./views/list-sites')
 SiteStatusesView = require('./views/site-statuses')
+StatusChartView = require("./views/status-chart")
 StatusCollection = require('./collections/status-collection')
 FormView = require('./views/form')
 SiteModel = require('./models/site')
@@ -29,5 +30,14 @@ module.exports = Marionette.Object.extend(
       reset: true
       success: ->
         showInRoot(new SiteStatusesView(collection: statusCollection))
+    )
+
+  viewChart: (id) ->
+    statusCollection = new StatusCollection(key: id)
+    statusCollection.url = "/sites/#{id}/checks"
+    statusCollection.fetch(
+      reset: true
+      success: ->
+        showInRoot(new StatusChartView(collection: statusCollection))
     )
 )

--- a/client/src/app/router.coffee
+++ b/client/src/app/router.coffee
@@ -7,5 +7,6 @@ module.exports = Marionette.AppRouter.extend(
     'sites/new': 'createSite'
     'sites': 'listSites'
     'sites/:id/checks': 'viewSite'
+    "sites/:id/chart": "viewChart"
     '': 'index'
 )

--- a/client/src/app/templates/chart.jade
+++ b/client/src/app/templates/chart.jade
@@ -1,0 +1,6 @@
+h3 Latest Status
+span= current
+.canvas-container
+  h4 Past Statuses
+  canvas(id="status-chart", width="400", height="400")
+a(href="#sites/#{siteKey}/checks") Detailed Status List

--- a/client/src/app/templates/list-statuses.jade
+++ b/client/src/app/templates/list-statuses.jade
@@ -1,4 +1,5 @@
 h3 Site Statuses
+a(href="#sites/#{siteKey}/chart") View Chart
 table(id="status-table")
   thead
     tr

--- a/client/src/app/views/site-statuses.coffee
+++ b/client/src/app/views/site-statuses.coffee
@@ -8,4 +8,7 @@ module.exports = Marionette.CompositeView.extend(
   childViewContainer: 'tbody'
   emptyView: NoSitesView
   template: require('../templates/list-statuses.jade')
+
+  templateHelpers: ->
+    siteKey: @collection.url.split('/')[2]
 )

--- a/client/src/app/views/status-chart.coffee
+++ b/client/src/app/views/status-chart.coffee
@@ -1,0 +1,39 @@
+$ = require("jquery")
+_ = require("lodash")
+Marionette = require("backbone.marionette")
+statusChartColors = require("../helpers/status-chart-colors")
+
+module.exports = Marionette.ItemView.extend(
+  template: require("../templates/chart.jade")
+
+  onShow: ->
+    @makeChart(@chartContext("status-chart"), @chartData(), @chartOptions())
+
+  templateHelpers: ->
+    siteKey: @collection.url.split('/')[2]
+    current: @collection.at(0).get('response')
+
+  chartContext: (canvasId) ->
+    document.getElementById(canvasId).getContext("2d")
+
+  chartOptions: ->
+    segmentStrokeWidth: 1
+    animationEasing: "linear"
+
+  chartData: ->
+    statuses = _.uniq(@collection.pluck('response'))
+    data = []
+
+    statuses.forEach( (status) =>
+      data.push(
+        _.extend(statusChartColors.findColorByCode(status),
+          { value: @collection.where(response: status).length }
+        )
+      )
+    )
+
+    return data
+
+  makeChart: (ctx, data, options) ->
+    new Chart(ctx).Pie(data, options)
+)

--- a/client/src/index.jade
+++ b/client/src/index.jade
@@ -5,5 +5,6 @@ html(lang="en")
     meta(name="viewport" content="width=device-width, initial-scale=1")
     title Situation Room
     link(rel="stylesheet" href="css/main.css")
+    script(src="http://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js")
   body
     script(type='text/javascript', src="js/main.js")


### PR DESCRIPTION
For each site, you can now view a chart of the site status codes for each time it was checked.

For viewing the charts themselves, I added in a new Marionette view and Jade template, as well as a helper to get the appropriate chart data color depending on the status code.
